### PR TITLE
Release: git-client v1.2.4

### DIFF
--- a/lib/Git.js
+++ b/lib/Git.js
@@ -209,7 +209,7 @@ class Git {
         const execOptions = {
             gitDir: this.gitDir,
             workTree: this.workTree,
-            maxBuffer: 1024 * 1024 // 1 MB output buffer
+            maxBuffer: 1024 * 1024 * 5 // 5 MB output buffer
         };
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-client",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Promise-based git client that mostly just executes the git binary",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- fix: increase output buffer to 5MB