### PR TITLE
Release: git-client v1.6.1

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 **/test/
 **/.vscode/
+.eslintrc.json

--- a/lib/Git.js
+++ b/lib/Git.js
@@ -178,7 +178,7 @@ class Git {
      * @param {string} ref Any commit ref
      */
     async getTreeHash (ref, { verify = true } = {}) {
-        return this.revParse({ verify }, `${ref}^{tree}`);
+        return this.revParse({ verify: verify || null }, `${ref}^{tree}`);
     }
 
     /**

--- a/lib/Git.js
+++ b/lib/Git.js
@@ -178,7 +178,7 @@ class Git {
      * @param {string} ref Any commit ref
      */
     async getTreeHash (ref, { verify = true } = {}) {
-        return this.revParse({ verify: verify || null }, `${ref}^{tree}`);
+        return this.revParse({ verify: verify || null }, `${ref}^{tree}`, { $nullOnError: true });
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-client",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Promise-based git client that mostly just executes the git binary",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- fix: omit --verify if not enabled instead of setting --no-verify
- fix: enable nullOnError for getTreeHash
- chore: exclude eslint config from npm publish