### PR TITLE
feat: add $config option to inject -c <key>=<value> overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ When passing options objects, the following special keys are supported:
 - `$nullOnError`: Return null instead of throwing on error
 - `$onStdout`: Callback for stdout in spawn mode
 - `$onStderr`: Callback for stderr in spawn mode
+- `$env`: Object of environment variables to set on the spawned process
+- `$config`: Object of `key=value` config overrides injected as `-c` flags before the subcommand (e.g. `{ $config: { 'gc.auto': '0' } }`)
 
 ### Common Methods
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,8 @@ declare module 'git-client' {
     $cwd?: string;
     /** Custom environment variables */
     $env?: Record<string, string>;
+    /** Inject `-c key=value` config overrides before the subcommand */
+    $config?: Record<string, string>;
     /** Additional options */
     $options?: Record<string, any>;
     /** Any git command options */

--- a/lib/Git.js
+++ b/lib/Git.js
@@ -714,6 +714,11 @@ class Git {
                         delete arg.$env;
                     }
 
+                    if ('$config' in arg) {
+                        execOptions.config = Object.assign(execOptions.config || {}, arg.$config);
+                        delete arg.$config;
+                    }
+
                     if ('$preserveEnv' in arg) {
                         execOptions.preserveEnv = arg.$preserveEnv;
                         delete arg.$preserveEnv;
@@ -763,6 +768,16 @@ class Git {
 
         if (execOptions.workTree) {
             gitOptions['work-tree'] = execOptions.workTree;
+        }
+
+        if (execOptions.config) {
+            const configArgs = [];
+            for (const key in execOptions.config) {
+                configArgs.push(`${key}=${execOptions.config[key]}`);
+            }
+            if (configArgs.length) {
+                gitOptions['c'] = configArgs;
+            }
         }
 
         commandArgs.unshift.apply(commandArgs, Git.cliOptionsToArgs(gitOptions));

--- a/test/git.js
+++ b/test/git.js
@@ -69,6 +69,33 @@ test('other git executes with correct git dir with override', async t => {
     t.is(await fs.realpath(gitDir), repo1Dir);
 });
 
+test('$config injects -c <key>=<value> before subcommand', async t => {
+    // Read back a config value that only exists via $config injection
+    const value = await git.config(
+        { $config: { 'holo.injected': 'yes' } },
+        '--get',
+        'holo.injected',
+    );
+
+    t.is(value, 'yes');
+});
+
+test('$config supports multiple entries', async t => {
+    const first = await git.config(
+        { $config: { 'holo.first': '1', 'holo.second': '2' } },
+        '--get',
+        'holo.first',
+    );
+    const second = await git.config(
+        { $config: { 'holo.first': '1', 'holo.second': '2' } },
+        '--get',
+        'holo.second',
+    );
+
+    t.is(first, '1');
+    t.is(second, '2');
+});
+
 test('checkout git repo to temporary directory', async t => {
     const [tmpWorkTree, tmpIndexFilePath] = await Promise.all([tmp.dir(), tmp.tmpName()]);
 


### PR DESCRIPTION
## Summary

Adds a `$config` option to the exec API that injects `-c key=value` flags between `git` and the subcommand. This lets callers override config per-invocation without mutating on-disk config.

```js
await git.fetch(
    { depth: 1, $config: { 'gc.auto': '0' } },
    url,
    ref,
);
```

Produces:

```
git --git-dir=… -c gc.auto=0 fetch --depth=1 <url> <ref>
```

Multiple entries are supported and turn into repeated `-c` flags via the existing array-valued option handling in `cliOptionsToArgs`.

## Motivation

Needed by hologit to disable git's background auto-gc during shallow source fetches. Background `gc --auto` (default `gc.autoDetach=true`) races with the next shallow fetch's `.git/shallow` write and triggers `fatal: shallow file has changed since we read it`. See [JarvusInnovations/hologit#450](https://github.com/JarvusInnovations/hologit/issues/450).

## Test plan

- [x] `npx ava --no-worker-threads test/git.js` — 17 tests pass, including two new ones covering single and multiple `$config` entries
- [x] Read back an injected config value via `git config --get` to verify the `-c` flags land before the subcommand