### PR TITLE
chore(ci): try publishing via a newer node version

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -15,13 +15,11 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
-        node-version: '22.x'
+        node-version: '24'
         registry-url: 'https://registry.npmjs.org'
-
-    - name: Upgrade npm for trusted publishing
-      run: npm install -g npm@latest
+        package-manager-cache: false  # never use caching in release builds
 
     - name: Place tag in environment
       run: |


### PR DESCRIPTION
The bundled npm in the Node 22 toolcache is broken — `npm install -g npm@latest` in the publish workflow fails with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/...
```

That's blocking the v1.12.0 release ([failing run](https://github.com/JarvusInnovations/git-client/actions/runs/26048629948)).

Same fix that resolved this on gitsheets in [JarvusInnovations/gitsheets@4784e80](https://github.com/JarvusInnovations/gitsheets/commit/4784e803b0965e166387366b5e87bb4977259755):

- `actions/setup-node` v4 → v6
- `node-version` 22.x → 24 (ships a working npm new enough for trusted publishing)
- `package-manager-cache: false` (never cache in release builds)
- Drop the `npm install -g npm@latest` step — no longer needed once the bundled npm works

## To actually publish v1.12.0 after merge

The publish workflow runs at the tag's commit, so just merging this won't fix the existing v1.12.0 tag. After merge to develop and fast-forward to main, the v1.12.0 tag will need to be moved to the new main HEAD and re-pushed (or cut a v1.12.1).